### PR TITLE
Add gettext to requirements for unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ print(_("unknown phrase")) -- prints "unknown phrase"
 
 ## Unit tests
 
-You need [busted][busted] to run unit tests.
+You need [busted][busted] and [gettext][gettext] to run unit tests.
 
 ```bash
 $ busted


### PR DESCRIPTION
Unit testing fails unless gettext is installed.

Should this also point to instruction installations for gettext?  brew install gettext works perfectly on linux, but it also requires a brew link --force gettext on mac.